### PR TITLE
feat: use singleQuote

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,4 +4,9 @@ module.exports = {
   /* This can help reduce diff sizes, so we generally like it
    * as a best practice to make code reviews just that tiny bit better. */
   trailingComma: "all",
+  
+  /* A single quote requires pressing only one key,
+   * but a double quote requires holding shift.
+   * So, we find single quotes easier to type and prefer them. */
+  singleQuote: true
 };


### PR DESCRIPTION
BREAKING CHANGE: Single quotes are now preferred over double quotes.

See the diff for an explanation.